### PR TITLE
Edited catch for NA distributions

### DIFF
--- a/R/sampleDistribution.R
+++ b/R/sampleDistribution.R
@@ -36,7 +36,7 @@
 
 sampleDistribution <- function(dist, nSamples = 10){
   
-  if(is.na(dist)){
+  if(!isS4(dist)){
     out <- rep(NA, nSamples)
   }else{
     out <- distr::r(dist)(nSamples)


### PR DESCRIPTION
is.na() used on S4 objects (i.e. when a custom distribution is present) resulted in unwanted warning messages. Now catching with !isS4()
