### PR TITLE
Disabled shorter indicator names when there are < 20 incators

### DIFF
--- a/R/plotWeights.R
+++ b/R/plotWeights.R
@@ -167,7 +167,7 @@ plotWeights <- function(x = NULL, group = "indic", allBars = FALSE, nrBars = 35,
   substringEnd <- 15
   cexn <- cex
   if (barnum <= 20) {
-    substringEnd <- 9
+    #substringEnd <- 9
     cexn <- cex*0.75/0.5
   }
 


### PR DESCRIPTION
Previous settings made the two indicators starting with "tilstand" indistinguishable (ecosystem åpent lavland).
